### PR TITLE
Add filter 'quick_mail_user_capability' to the user capability check

### DIFF
--- a/quick-mail.php
+++ b/quick-mail.php
@@ -145,7 +145,7 @@ function init_quick_mail() {
 
 function init_quick_mail_menu() {
 	$title = __( 'Quick Mail', 'quick-mail' );
-	$page = add_submenu_page( 'tools.php', $title, $title, 'publish_posts', 'quick_mail_form', 'quick_mail_form' );
+	$page = add_submenu_page( 'tools.php', $title, $title, apply_filters( 'quick_mail_user_capability', 'publish_posts' ), 'quick_mail_form', 'quick_mail_form' );
 	add_action( 'admin_print_styles-' . $page, 'init_quick_mail_style' );
 } // end init_quick_mail_menu
 


### PR DESCRIPTION
I've added a filter called `quick_mail_user_capability` to the `add_submenu_page` call, that allows the user capability to be changed from the default `publish_posts`. It would be very handy  if you would be happy to incorporate this.

In my case I only want users who can edit other users' posts to be able to send mails, so I just add the following code to `functions.php`:

```
add_filter( 'quick_mail_user_capability', 'my_quick_mail_user_capability' );

function my_quick_mail_user_capability( $capability ) {
    return 'edit_others_posts';
}
```
