### PR TITLE
Fixed empty needle

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Quick Mail WordPress Plugin
 Send text or html email with attachments and shortcodes from WP Dashboard or command line. Send private replies to comments. Select recipient from users or commenters. Includes WP-CLI command.
 
 * Requires: [WordPress 4.6](https://wordpress.org/support/wordpress-version/version-4-6/)
-* Tested with: [WordPress 5.8.2](https://wordpress.org/support/wordpress-version/version-5-8-2/)
-* Stable version: [4.1.5](https://github.com/mitchelldmiller/quick-mail-wp-plugin/releases/latest)
+* Tested with: [WordPress 5.8.3](https://wordpress.org/support/wordpress-version/version-5-8-3/)
+* Stable version: [4.1.6](https://github.com/mitchelldmiller/quick-mail-wp-plugin/releases/latest)
 
 Description
 -----------
@@ -101,8 +101,6 @@ __Where Do I Find Sent Emails?__
 * You should be able to find sent emails in your email account's Sent Mail folder.
 
 * Delivery services like [Mailgun](https://www.mailgun.com/), [SparkPost](https://wordpress.org/plugins/sparkpost/) and [Sendgrid](https://sendgrid.com/) also provide this information. 
-
-* [WP Mail Logging](https://wordpress.org/plugins/wp-mail-logging/) plugin saves a list of sent emails, with content of message. Plugin shows number of attachments, but does not save attachments or file names.
 
 __Selecting Recipients__
 

--- a/lang/quick-mail.pot
+++ b/lang/quick-mail.pot
@@ -1,24 +1,24 @@
-# Copyright (C) 2021 Mitchell D. Miller
+# Copyright (C) 2022 Mitchell D. Miller
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: Quick Mail 4.1.5\n"
+"Project-Id-Version: Quick Mail 4.1.6\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/quick-mail-wp-plugin\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2021-11-20T18:47:09-05:00\n"
+"POT-Creation-Date: 2022-01-15T21:20:15-05:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.5.0\n"
 "X-Domain: quick-mail\n"
 
 #. Plugin Name of the plugin
 #: quick-mail.php:223
-#: quick-mail.php:1737
-#: quick-mail.php:1739
-#: quick-mail.php:2699
+#: quick-mail.php:1740
+#: quick-mail.php:1742
+#: quick-mail.php:2702
 msgid "Quick Mail"
 msgstr ""
 
@@ -39,16 +39,16 @@ msgid "https://mitchelldmiller.com/"
 msgstr ""
 
 #: inc/class-quick-mail-command.php:137
-#: quick-mail.php:2277
-#: quick-mail.php:2293
-#: quick-mail.php:2810
+#: quick-mail.php:2280
+#: quick-mail.php:2296
+#: quick-mail.php:2813
 msgid "Using"
 msgstr ""
 
 #: inc/class-quick-mail-command.php:139
-#: quick-mail.php:2272
-#: quick-mail.php:2279
-#: quick-mail.php:2812
+#: quick-mail.php:2275
+#: quick-mail.php:2282
+#: quick-mail.php:2815
 msgid "credentials"
 msgstr ""
 
@@ -132,27 +132,27 @@ msgid "Not sending file. Attachment message ignored."
 msgstr ""
 
 #: inc/class-quick-mail-command.php:422
-#: quick-mail.php:1605
+#: quick-mail.php:1608
 msgid "Cannot send mail to over 100 recipients."
 msgstr ""
 
 #: inc/class-quick-mail-command.php:432
-#: quick-mail.php:1737
+#: quick-mail.php:1740
 msgid "TEST MODE"
 msgstr ""
 
 #: inc/class-quick-mail-command.php:432
-#: quick-mail.php:1638
-#: quick-mail.php:1643
-#: quick-mail.php:1645
-#: quick-mail.php:1787
-#: quick-mail.php:1814
+#: quick-mail.php:1641
+#: quick-mail.php:1646
+#: quick-mail.php:1648
+#: quick-mail.php:1790
+#: quick-mail.php:1817
 msgid "To"
 msgstr ""
 
 #: inc/class-quick-mail-command.php:438
-#: quick-mail.php:1654
-#: quick-mail.php:1656
+#: quick-mail.php:1657
+#: quick-mail.php:1659
 msgid "Error sending mail"
 msgstr ""
 
@@ -195,16 +195,16 @@ msgstr ""
 #: inc/class-quickmailsender.php:93
 #: inc/class-quickmailutil.php:305
 #: inc/class-quickmailutil.php:330
-#: quick-mail.php:573
-#: quick-mail.php:1295
-#: quick-mail.php:1448
-#: quick-mail.php:1614
+#: quick-mail.php:576
+#: quick-mail.php:1298
+#: quick-mail.php:1451
+#: quick-mail.php:1617
 msgid "Mail Error"
 msgstr ""
 
 #: inc/class-quickmailutil.php:306
 #: inc/class-quickmailutil.php:331
-#: quick-mail.php:1435
+#: quick-mail.php:1438
 msgid "Error: Incomplete User Profile"
 msgstr ""
 
@@ -221,13 +221,13 @@ msgid "Follow development on Github"
 msgstr ""
 
 #: quick-mail.php:212
-#: quick-mail.php:2191
-#: quick-mail.php:3213
+#: quick-mail.php:2194
+#: quick-mail.php:3216
 msgid "FAQ"
 msgstr ""
 
 #: quick-mail.php:214
-#: quick-mail.php:2855
+#: quick-mail.php:2858
 msgid "Github Issues"
 msgstr ""
 
@@ -240,7 +240,7 @@ msgid "has more information."
 msgstr ""
 
 #: quick-mail.php:217
-#: quick-mail.php:2856
+#: quick-mail.php:2859
 msgid "Please use"
 msgstr ""
 
@@ -249,7 +249,7 @@ msgid "to ask questions and report problems."
 msgstr ""
 
 #: quick-mail.php:238
-#: quick-mail.php:2397
+#: quick-mail.php:2400
 msgid "Send private replies to comments."
 msgstr ""
 
@@ -269,852 +269,852 @@ msgstr ""
 msgid "Reply to Comments"
 msgstr ""
 
-#: quick-mail.php:589
+#: quick-mail.php:592
 msgid "Quick Mail requires WordPress 4.6 or greater."
 msgstr ""
 
-#: quick-mail.php:594
+#: quick-mail.php:597
 msgid "Quick Mail requires cURL extension."
 msgstr ""
 
-#: quick-mail.php:652
+#: quick-mail.php:655
 msgid "Welcome to Quick Mail"
 msgstr ""
 
-#: quick-mail.php:653
+#: quick-mail.php:656
 msgid "Please verify your settings before using Quick Mail."
 msgstr ""
 
-#: quick-mail.php:751
+#: quick-mail.php:754
 msgid "Duplicate"
 msgstr ""
 
-#: quick-mail.php:760
+#: quick-mail.php:763
 msgid "Clear 1 saved address"
 msgstr ""
 
 #. translators: number of saved email addresses
-#: quick-mail.php:762
+#: quick-mail.php:765
 msgid "Clear %s saved addresses"
 msgstr ""
 
-#: quick-mail.php:866
-#: quick-mail.php:972
+#: quick-mail.php:869
+#: quick-mail.php:975
 msgid "No Role"
 msgstr ""
 
-#: quick-mail.php:1017
+#: quick-mail.php:1020
 msgid "No comments for you."
 msgstr ""
 
-#: quick-mail.php:1017
+#: quick-mail.php:1020
 msgid "No recent comments for you."
 msgstr ""
 
-#: quick-mail.php:1266
+#: quick-mail.php:1269
 msgid "Please grant permission to use your email address."
 msgstr ""
 
-#: quick-mail.php:1266
+#: quick-mail.php:1269
 msgid "Privacy Error"
 msgstr ""
 
-#: quick-mail.php:1295
+#: quick-mail.php:1298
 msgid "Comments disabled by system administrator."
 msgstr ""
 
-#: quick-mail.php:1322
+#: quick-mail.php:1325
 msgid "Cannot reply. Invalid mail address."
 msgstr ""
 
-#: quick-mail.php:1440
-#: quick-mail.php:1934
+#: quick-mail.php:1443
+#: quick-mail.php:1937
 msgid "Login Expired. Refresh Page."
 msgstr ""
 
-#: quick-mail.php:1448
-#: quick-mail.php:1473
-#: quick-mail.php:1482
-#: quick-mail.php:1506
-#: quick-mail.php:1733
+#: quick-mail.php:1451
+#: quick-mail.php:1476
+#: quick-mail.php:1485
+#: quick-mail.php:1509
+#: quick-mail.php:1736
 msgid "Invalid mail address"
 msgstr ""
 
-#: quick-mail.php:1457
-#: quick-mail.php:1508
-#: quick-mail.php:1762
+#: quick-mail.php:1460
+#: quick-mail.php:1511
+#: quick-mail.php:1765
 msgid "Duplicate mail address"
 msgstr ""
 
-#: quick-mail.php:1517
+#: quick-mail.php:1520
 msgid "No subject"
 msgstr ""
 
-#: quick-mail.php:1523
+#: quick-mail.php:1526
 msgid "Please enter your message"
 msgstr ""
 
-#: quick-mail.php:1557
+#: quick-mail.php:1560
 msgid "Duplicate attachments"
 msgstr ""
 
-#: quick-mail.php:1566
+#: quick-mail.php:1569
 msgid "Missing temporary directory"
 msgstr ""
 
-#: quick-mail.php:1572
+#: quick-mail.php:1575
 msgid "Error moving file to"
 msgstr ""
 
-#: quick-mail.php:1577
+#: quick-mail.php:1580
 msgid "Uploaded file was too large"
 msgstr ""
 
-#: quick-mail.php:1579
+#: quick-mail.php:1582
 msgid "File Upload Error"
 msgstr ""
 
-#: quick-mail.php:1607
+#: quick-mail.php:1610
 msgid "Edit mail."
 msgstr ""
 
-#: quick-mail.php:1640
+#: quick-mail.php:1643
 msgid "Message Sent"
 msgstr ""
 
-#: quick-mail.php:1641
-#: quick-mail.php:1770
-#: quick-mail.php:1820
-#: quick-mail.php:1830
+#: quick-mail.php:1644
+#: quick-mail.php:1773
+#: quick-mail.php:1823
+#: quick-mail.php:1833
 msgid "CC"
 msgstr ""
 
-#: quick-mail.php:1641
-#: quick-mail.php:1771
-#: quick-mail.php:1821
+#: quick-mail.php:1644
+#: quick-mail.php:1774
+#: quick-mail.php:1824
 msgid "BCC"
 msgstr ""
 
-#: quick-mail.php:1649
+#: quick-mail.php:1652
 msgid "Mailgun Error sending mail"
 msgstr ""
 
-#: quick-mail.php:1651
+#: quick-mail.php:1654
 msgid "SparkPost Error sending mail"
 msgstr ""
 
-#: quick-mail.php:1653
-#: quick-mail.php:2267
-#: quick-mail.php:2804
-#: quick-mail.php:2970
+#: quick-mail.php:1656
+#: quick-mail.php:2270
+#: quick-mail.php:2807
+#: quick-mail.php:2973
 msgid "SendGrid"
 msgstr ""
 
-#: quick-mail.php:1680
+#: quick-mail.php:1683
 msgid "Error Deleting Upload"
 msgstr ""
 
-#: quick-mail.php:1703
-#: quick-mail.php:3142
+#: quick-mail.php:1706
+#: quick-mail.php:3145
 msgid "File uploads are not available on your device"
 msgstr ""
 
-#: quick-mail.php:1705
-#: quick-mail.php:3140
+#: quick-mail.php:1708
+#: quick-mail.php:3143
 msgid "File uploads were disabled by system administrator"
 msgstr ""
 
-#: quick-mail.php:1729
+#: quick-mail.php:1732
 msgid "Cannot verify address"
 msgstr ""
 
-#: quick-mail.php:1731
+#: quick-mail.php:1734
 msgid "Invalid or blocked mail address"
 msgstr ""
 
-#: quick-mail.php:1764
+#: quick-mail.php:1767
 msgid "Quick Mail requires Javascript"
 msgstr ""
 
-#: quick-mail.php:1787
-#: quick-mail.php:2860
+#: quick-mail.php:1790
+#: quick-mail.php:2863
 msgid "Commenters"
 msgstr ""
 
-#: quick-mail.php:1788
+#: quick-mail.php:1791
 msgid "Message"
 msgstr ""
 
-#: quick-mail.php:1788
+#: quick-mail.php:1791
 msgid "Reply"
 msgstr ""
 
-#: quick-mail.php:1791
+#: quick-mail.php:1794
 msgid "From"
 msgstr ""
 
-#: quick-mail.php:1814
-#: quick-mail.php:1830
+#: quick-mail.php:1817
+#: quick-mail.php:1833
 msgid "Recent"
 msgstr ""
 
-#: quick-mail.php:1835
+#: quick-mail.php:1838
 msgid "Subject"
 msgstr ""
 
-#: quick-mail.php:1842
-#: quick-mail.php:1846
-#: quick-mail.php:1850
-#: quick-mail.php:1854
-#: quick-mail.php:1858
-#: quick-mail.php:1862
+#: quick-mail.php:1845
+#: quick-mail.php:1849
+#: quick-mail.php:1853
+#: quick-mail.php:1857
+#: quick-mail.php:1861
+#: quick-mail.php:1865
 msgid "Attachment"
 msgstr ""
 
-#: quick-mail.php:1885
-#: quick-mail.php:1886
+#: quick-mail.php:1888
+#: quick-mail.php:1889
 msgid "Send Mail"
 msgstr ""
 
-#: quick-mail.php:2107
+#: quick-mail.php:2110
 msgid "Option Updated"
 msgstr ""
 
-#: quick-mail.php:2145
-#: quick-mail.php:2748
+#: quick-mail.php:2148
+#: quick-mail.php:2751
 msgid "NOTE"
 msgstr ""
 
-#: quick-mail.php:2146
+#: quick-mail.php:2149
 msgid "Quick Mail needs three non-admin users for sender, recipient, CC to access User List."
 msgstr ""
 
-#: quick-mail.php:2183
-#: quick-mail.php:2832
+#: quick-mail.php:2186
+#: quick-mail.php:2835
 msgid "http://php.net/manual/en/function.checkdnsrr.php"
 msgstr ""
 
-#: quick-mail.php:2185
+#: quick-mail.php:2188
 msgid "when"
 msgstr ""
 
-#: quick-mail.php:2185
-#: quick-mail.php:2469
-#: quick-mail.php:2940
+#: quick-mail.php:2188
+#: quick-mail.php:2472
+#: quick-mail.php:2943
 msgid "Do Not Show Users"
 msgstr ""
 
-#: quick-mail.php:2186
+#: quick-mail.php:2189
 msgid "is selected"
 msgstr ""
 
-#: quick-mail.php:2187
+#: quick-mail.php:2190
 msgid "Verifies domain with"
 msgstr ""
 
-#: quick-mail.php:2190
+#: quick-mail.php:2193
 msgid "https://mitchelldmiller.github.io/quick-mail-wp-plugin/#frequently-asked-questions"
 msgstr ""
 
-#: quick-mail.php:2192
+#: quick-mail.php:2195
 msgid "http://php.net/manual/en/function.idn-to-ascii.php"
 msgstr ""
 
-#: quick-mail.php:2194
+#: quick-mail.php:2197
 msgid "function not found"
 msgstr ""
 
-#: quick-mail.php:2195
+#: quick-mail.php:2198
 msgid "Cannot verify international domains"
 msgstr ""
 
-#: quick-mail.php:2195
+#: quick-mail.php:2198
 msgid "because"
 msgstr ""
 
-#: quick-mail.php:2196
+#: quick-mail.php:2199
 msgid "Please read"
 msgstr ""
 
-#: quick-mail.php:2202
+#: quick-mail.php:2205
 msgid "Apply"
 msgstr ""
 
-#: quick-mail.php:2204
+#: quick-mail.php:2207
 msgid "to HTML messages."
 msgstr ""
 
-#: quick-mail.php:2211
+#: quick-mail.php:2214
 msgid "Select recipient from commenters"
 msgstr ""
 
-#: quick-mail.php:2213
+#: quick-mail.php:2216
 msgid "Display Commenters instead of users"
 msgstr ""
 
-#: quick-mail.php:2239
+#: quick-mail.php:2242
 msgid "Using Mailgun credentials"
 msgstr ""
 
-#: quick-mail.php:2240
+#: quick-mail.php:2243
 msgid "Sending mail with your Mailgun name and mail address."
 msgstr ""
 
-#: quick-mail.php:2242
-#: quick-mail.php:2256
+#: quick-mail.php:2245
+#: quick-mail.php:2259
 msgid "Mailgun is active"
 msgstr ""
 
-#: quick-mail.php:2244
-#: quick-mail.php:2258
+#: quick-mail.php:2247
+#: quick-mail.php:2261
 msgid "Administrator is using Mailgun to send mail."
 msgstr ""
 
-#: quick-mail.php:2246
-#: quick-mail.php:2260
+#: quick-mail.php:2249
+#: quick-mail.php:2263
 msgid "Sending mail with Mailgun API."
 msgstr ""
 
-#: quick-mail.php:2253
+#: quick-mail.php:2256
 msgid "Using SparkPost credentials"
 msgstr ""
 
-#: quick-mail.php:2254
+#: quick-mail.php:2257
 msgid "Sending mail with your SparkPost name and mail address."
 msgstr ""
 
-#: quick-mail.php:2270
+#: quick-mail.php:2273
 msgid "Use"
 msgstr ""
 
-#: quick-mail.php:2280
-#: quick-mail.php:2813
+#: quick-mail.php:2283
+#: quick-mail.php:2816
 msgid "to send mail for Administrators"
 msgstr ""
 
-#: quick-mail.php:2286
+#: quick-mail.php:2289
 msgid "Administrator is using"
 msgstr ""
 
-#: quick-mail.php:2288
-#: quick-mail.php:2295
+#: quick-mail.php:2291
+#: quick-mail.php:2298
 msgid "to send mail"
 msgstr ""
 
-#: quick-mail.php:2315
-#: quick-mail.php:2716
+#: quick-mail.php:2318
+#: quick-mail.php:2719
 msgid "Quick Mail Options"
 msgstr ""
 
-#: quick-mail.php:2320
+#: quick-mail.php:2323
 msgid "Privacy"
 msgstr ""
 
-#: quick-mail.php:2322
+#: quick-mail.php:2325
 msgid "Grant Quick Mail permission to use your email address."
 msgstr ""
 
-#: quick-mail.php:2323
+#: quick-mail.php:2326
 msgid "Permission is required to send mail."
 msgstr ""
 
-#: quick-mail.php:2325
+#: quick-mail.php:2328
 msgid "Grant Quick Mail permission to save recipient addresses."
 msgstr ""
 
-#: quick-mail.php:2326
+#: quick-mail.php:2329
 msgid "Permission is required to save addresses. Addresses will not be shared."
 msgstr ""
 
-#: quick-mail.php:2332
-#: quick-mail.php:2846
-#: quick-mail.php:2886
+#: quick-mail.php:2335
+#: quick-mail.php:2849
+#: quick-mail.php:2889
 msgid "Administration"
 msgstr ""
 
-#: quick-mail.php:2348
-#: quick-mail.php:2826
+#: quick-mail.php:2351
+#: quick-mail.php:2829
 msgid "Hide Administrator Profiles"
 msgstr ""
 
 #. translators: %s: number of administrator profiles
-#: quick-mail.php:2352
+#: quick-mail.php:2355
 msgid "%s administrator profile"
 msgid_plural "%s administrator profiles"
 msgstr[0] ""
 msgstr[1] ""
 
-#: quick-mail.php:2353
+#: quick-mail.php:2356
 msgid "User list will not include"
 msgstr ""
 
-#: quick-mail.php:2359
+#: quick-mail.php:2362
 msgid "Disable Replies to Comments"
 msgstr ""
 
-#: quick-mail.php:2360
+#: quick-mail.php:2363
 msgid "Users will not see commenter list."
 msgstr ""
 
-#: quick-mail.php:2362
-#: quick-mail.php:2882
+#: quick-mail.php:2365
+#: quick-mail.php:2885
 msgid "Grant Authors permission to reply to comments"
 msgstr ""
 
-#: quick-mail.php:2363
+#: quick-mail.php:2366
 msgid "Authors can see commenter list or user list."
 msgstr ""
 
-#: quick-mail.php:2365
+#: quick-mail.php:2368
 msgid "Grant Editors access to user list."
 msgstr ""
 
-#: quick-mail.php:2366
+#: quick-mail.php:2369
 msgid "Let editors see user list."
 msgstr ""
 
-#: quick-mail.php:2368
-#: quick-mail.php:2830
+#: quick-mail.php:2371
+#: quick-mail.php:2833
 msgid "Verify recipient email domains"
 msgstr ""
 
-#: quick-mail.php:2371
-#: quick-mail.php:2373
-#: quick-mail.php:2838
+#: quick-mail.php:2374
+#: quick-mail.php:2376
+#: quick-mail.php:2841
 msgid "Banned Domains"
 msgstr ""
 
-#: quick-mail.php:2382
-#: quick-mail.php:2910
-#: quick-mail.php:2917
+#: quick-mail.php:2385
+#: quick-mail.php:2913
+#: quick-mail.php:2920
 msgid "Add Paragraphs"
 msgstr ""
 
-#: quick-mail.php:2384
+#: quick-mail.php:2387
 msgid "Add Paragraphs to sent mail"
 msgstr ""
 
-#: quick-mail.php:2389
-#: quick-mail.php:2945
+#: quick-mail.php:2392
+#: quick-mail.php:2948
 msgid "User Display"
 msgstr ""
 
-#: quick-mail.php:2399
-#: quick-mail.php:2873
+#: quick-mail.php:2402
+#: quick-mail.php:2876
 msgid "Limit comments"
 msgstr ""
 
-#: quick-mail.php:2400
+#: quick-mail.php:2403
 msgid "days"
 msgstr ""
 
-#: quick-mail.php:2401
+#: quick-mail.php:2404
 msgid "Limit displayed comments to a number of days."
 msgstr ""
 
-#: quick-mail.php:2415
-#: quick-mail.php:2929
+#: quick-mail.php:2418
+#: quick-mail.php:2932
 msgid "Show user roles"
 msgstr ""
 
-#: quick-mail.php:2416
-#: quick-mail.php:2930
+#: quick-mail.php:2419
+#: quick-mail.php:2933
 msgid "Let administrators see role on user list."
 msgstr ""
 
-#: quick-mail.php:2424
-#: quick-mail.php:2933
+#: quick-mail.php:2427
+#: quick-mail.php:2936
 msgid "Show All Users"
 msgstr ""
 
-#: quick-mail.php:2431
+#: quick-mail.php:2434
 msgid "Show all users sorted by nickname"
 msgstr ""
 
-#: quick-mail.php:2434
-#: quick-mail.php:2457
+#: quick-mail.php:2437
+#: quick-mail.php:2460
 msgid "matching users"
 msgstr ""
 
-#: quick-mail.php:2445
-#: quick-mail.php:2937
+#: quick-mail.php:2448
+#: quick-mail.php:2940
 msgid "Show Users with Names"
 msgstr ""
 
-#: quick-mail.php:2453
+#: quick-mail.php:2456
 msgid "Show users with names, sorted by last name"
 msgstr ""
 
-#: quick-mail.php:2474
+#: quick-mail.php:2477
 msgid "Need three users to display User List for sender, recipient, CC."
 msgstr ""
 
-#: quick-mail.php:2476
+#: quick-mail.php:2479
 msgid "User List was disabled by system administrator."
 msgstr ""
 
-#: quick-mail.php:2481
+#: quick-mail.php:2484
 msgid "Enter address to send mail."
 msgstr ""
 
-#: quick-mail.php:2481
+#: quick-mail.php:2484
 msgid "Saves 12 addresses."
 msgstr ""
 
-#: quick-mail.php:2483
+#: quick-mail.php:2486
 msgid "Save Options"
 msgstr ""
 
-#: quick-mail.php:2622
-#: quick-mail.php:2650
+#: quick-mail.php:2625
+#: quick-mail.php:2653
 msgid "Private Reply"
 msgstr ""
 
-#: quick-mail.php:2733
+#: quick-mail.php:2736
 msgid "Send Reliable Email from WordPress with Quick Mail has additional information."
 msgstr ""
 
-#: quick-mail.php:2749
+#: quick-mail.php:2752
 msgid "Sender, recipient, CC."
 msgstr ""
 
-#: quick-mail.php:2769
+#: quick-mail.php:2772
 msgid "User totals are adjusted because administrator profiles are hidden"
 msgstr ""
 
-#: quick-mail.php:2774
+#: quick-mail.php:2777
 msgid "Three non-administrator profiles are required for user lists."
 msgstr ""
 
-#: quick-mail.php:2785
+#: quick-mail.php:2788
 msgid "SparkPost plugin is active"
 msgstr ""
 
-#: quick-mail.php:2787
+#: quick-mail.php:2790
 msgid "Administrators send mail with SparkPost credentials"
 msgstr ""
 
-#: quick-mail.php:2789
+#: quick-mail.php:2792
 msgid "Sending mail with SparkPost"
 msgstr ""
 
-#: quick-mail.php:2794
+#: quick-mail.php:2797
 msgid "Mailgun plugin is active"
 msgstr ""
 
-#: quick-mail.php:2796
+#: quick-mail.php:2799
 msgid "Administrators send mail with Mailgun credentials"
 msgstr ""
 
-#: quick-mail.php:2798
+#: quick-mail.php:2801
 msgid "Sending mail with Mailgun"
 msgstr ""
 
-#: quick-mail.php:2805
+#: quick-mail.php:2808
 msgid "plugin is active"
 msgstr ""
 
-#: quick-mail.php:2818
+#: quick-mail.php:2821
 msgid "Sending mail with"
 msgstr ""
 
-#: quick-mail.php:2820
+#: quick-mail.php:2823
 msgid "plugin"
 msgstr ""
 
-#: quick-mail.php:2827
+#: quick-mail.php:2830
 msgid "Prevent users from sending email to administrators"
 msgstr ""
 
-#: quick-mail.php:2828
+#: quick-mail.php:2831
 msgid "Grant Editors access to user list"
 msgstr ""
 
-#: quick-mail.php:2829
+#: quick-mail.php:2832
 msgid "Otherwise only administrators can view the user list."
 msgstr ""
 
-#: quick-mail.php:2831
+#: quick-mail.php:2834
 msgid "Check if recipient domain accepts email, when user enters the address."
 msgstr ""
 
-#: quick-mail.php:2833
+#: quick-mail.php:2836
 msgid "Checks domain with"
 msgstr ""
 
-#: quick-mail.php:2836
+#: quick-mail.php:2839
 msgid "Addresses selected from user list are validated by WordPress, when user is added or updated."
 msgstr ""
 
-#: quick-mail.php:2837
+#: quick-mail.php:2840
 msgid "Turn verification off if Quick Mail rejects a valid address."
 msgstr ""
 
-#: quick-mail.php:2839
+#: quick-mail.php:2842
 msgid "Prevent users from sending email to selected domains."
 msgstr ""
 
-#: quick-mail.php:2840
+#: quick-mail.php:2843
 msgid "Enter domains. Use a space or comma to separate each domain."
 msgstr ""
 
-#: quick-mail.php:2841
+#: quick-mail.php:2844
 msgid "Quick Mail verifies domain before adding it."
 msgstr ""
 
-#: quick-mail.php:2857
+#: quick-mail.php:2860
 msgid "to ask questions and report problems"
 msgstr ""
 
-#: quick-mail.php:2862
+#: quick-mail.php:2865
 msgid "Display list of commenters, instead of users."
 msgstr ""
 
-#: quick-mail.php:2863
+#: quick-mail.php:2866
 msgid "Select recipient from commenters."
 msgstr ""
 
-#: quick-mail.php:2864
+#: quick-mail.php:2867
 msgid "enabling comments"
 msgstr ""
 
-#: quick-mail.php:2865
+#: quick-mail.php:2868
 msgid "discussion settings"
 msgstr ""
 
-#: quick-mail.php:2866
+#: quick-mail.php:2869
 msgid "See"
 msgstr ""
 
-#: quick-mail.php:2867
+#: quick-mail.php:2870
 msgid "for additional information."
 msgstr ""
 
-#: quick-mail.php:2868
+#: quick-mail.php:2871
 msgid "and"
 msgstr ""
 
-#: quick-mail.php:2869
+#: quick-mail.php:2872
 msgid "Reply to comments on your published content."
 msgstr ""
 
-#: quick-mail.php:2870
+#: quick-mail.php:2873
 msgid "Comments are often disabled on older content."
 msgstr ""
 
-#: quick-mail.php:2871
+#: quick-mail.php:2874
 msgid "Comments must be enabled to reply."
 msgstr ""
 
-#: quick-mail.php:2872
+#: quick-mail.php:2875
 msgid "Invalid mail addresses are not displayed."
 msgstr ""
 
-#: quick-mail.php:2874
+#: quick-mail.php:2877
 msgid "Limit displayed comments to past number of days."
 msgstr ""
 
-#: quick-mail.php:2875
+#: quick-mail.php:2878
 msgid "Hide comments to posts modified over selected days ago."
 msgstr ""
 
-#: quick-mail.php:2881
+#: quick-mail.php:2884
 msgid "Select Disable Replies to Comments to remove this feature."
 msgstr ""
 
-#: quick-mail.php:2885
+#: quick-mail.php:2888
 msgid "to let authors use this feature"
 msgstr ""
 
-#: quick-mail.php:2888
+#: quick-mail.php:2891
 msgid "Email domains are always validated."
 msgstr ""
 
-#: quick-mail.php:2905
+#: quick-mail.php:2908
 msgid "Add line breaks and paragraphs to HTML mail"
 msgstr ""
 
-#: quick-mail.php:2906
+#: quick-mail.php:2909
 msgid "with"
 msgstr ""
 
-#: quick-mail.php:2907
+#: quick-mail.php:2910
 msgid "Many plugins change the WordPress editor"
 msgstr ""
 
-#: quick-mail.php:2908
+#: quick-mail.php:2911
 msgid "Test this option on your system to know if you need it"
 msgstr ""
 
-#: quick-mail.php:2934
+#: quick-mail.php:2937
 msgid "Select users by WordPress nickname"
 msgstr ""
 
-#: quick-mail.php:2938
+#: quick-mail.php:2941
 msgid "Select users with first and last names"
 msgstr ""
 
-#: quick-mail.php:2941
+#: quick-mail.php:2944
 msgid "Enter user addresses. 12 addresses are saved"
 msgstr ""
 
-#: quick-mail.php:2956
+#: quick-mail.php:2959
 msgid "Several"
 msgstr ""
 
-#: quick-mail.php:2957
+#: quick-mail.php:2960
 msgid "https://wordpress.org/plugins/search/smtp/"
 msgstr ""
 
-#: quick-mail.php:2958
-#: quick-mail.php:3027
+#: quick-mail.php:2961
+#: quick-mail.php:3030
 msgid "SMTP Plugins"
 msgstr ""
 
-#: quick-mail.php:2960
+#: quick-mail.php:2963
 msgid "let you send mail from a public mail account"
 msgstr ""
 
-#: quick-mail.php:2961
+#: quick-mail.php:2964
 msgid "Quick Mail supports"
 msgstr ""
 
-#: quick-mail.php:2964
+#: quick-mail.php:2967
 msgid "https://www.mailgun.com/"
 msgstr ""
 
-#: quick-mail.php:2965
+#: quick-mail.php:2968
 msgid "Mailgun"
 msgstr ""
 
-#: quick-mail.php:2969
+#: quick-mail.php:2972
 msgid "https://sendgrid.com/"
 msgstr ""
 
-#: quick-mail.php:2974
+#: quick-mail.php:2977
 msgid "https://sparkpost.com/"
 msgstr ""
 
-#: quick-mail.php:2975
+#: quick-mail.php:2978
 msgid "SparkPost"
 msgstr ""
 
-#: quick-mail.php:2987
+#: quick-mail.php:2990
 msgid "How to Fix Delivery Errors"
 msgstr ""
 
-#: quick-mail.php:2991
+#: quick-mail.php:2994
 msgid "Delivering mail with SparkPost."
 msgstr ""
 
-#: quick-mail.php:2993
+#: quick-mail.php:2996
 msgid "Delivering mail with Mailgun."
 msgstr ""
 
-#: quick-mail.php:2995
+#: quick-mail.php:2998
 msgid "Delivering mail with SendGrid."
 msgstr ""
 
-#: quick-mail.php:3001
+#: quick-mail.php:3004
 msgid "Excellent!"
 msgstr ""
 
-#: quick-mail.php:3009
+#: quick-mail.php:3012
 msgid "Use these products and services with Quick Mail to fix delivery errors"
 msgstr ""
 
-#: quick-mail.php:3012
+#: quick-mail.php:3015
 msgid "Mail Delivery Service"
 msgstr ""
 
-#: quick-mail.php:3016
+#: quick-mail.php:3019
 msgid "Use a mail delivery service to send reliable email anywhere."
 msgstr ""
 
-#: quick-mail.php:3021
+#: quick-mail.php:3024
 msgid "Mailgun, SparkPost and SendGrid offer free plans with limited usage."
 msgstr ""
 
-#: quick-mail.php:3023
+#: quick-mail.php:3026
 msgid "Quick Mail is tested with Mailgun and SendGrid."
 msgstr ""
 
-#: quick-mail.php:3036
+#: quick-mail.php:3039
 msgid "Delivery Errors"
 msgstr ""
 
-#: quick-mail.php:3046
+#: quick-mail.php:3049
 msgid "wp help quick-mail"
 msgstr ""
 
-#: quick-mail.php:3047
+#: quick-mail.php:3050
 msgid "Use Quick Mail with WP-CLI"
 msgstr ""
 
-#: quick-mail.php:3048
+#: quick-mail.php:3051
 msgid "Send files, documents, Web pages from the command line"
 msgstr ""
 
-#: quick-mail.php:3051
+#: quick-mail.php:3054
 msgid "Enter"
 msgstr ""
 
-#: quick-mail.php:3053
+#: quick-mail.php:3056
 msgid "to get started"
 msgstr ""
 
-#: quick-mail.php:3059
+#: quick-mail.php:3062
 msgid "WP-CLI"
 msgstr ""
 
-#: quick-mail.php:3118
+#: quick-mail.php:3121
 msgid "Adding CC"
 msgstr ""
 
-#: quick-mail.php:3119
+#: quick-mail.php:3122
 msgid "Enter multiple addresses by separating them with a space or comma."
 msgstr ""
 
-#: quick-mail.php:3120
+#: quick-mail.php:3123
 msgid "Press Command key while clicking, to select multiple users."
 msgstr ""
 
-#: quick-mail.php:3121
+#: quick-mail.php:3124
 msgid "Press Control key while clicking, to select multiple users."
 msgstr ""
 
-#: quick-mail.php:3122
+#: quick-mail.php:3125
 msgid "You can select multiple users"
 msgstr ""
 
-#: quick-mail.php:3135
+#: quick-mail.php:3138
 msgid "Attachments"
 msgstr ""
 
-#: quick-mail.php:3144
+#: quick-mail.php:3147
 msgid "You can attach multiple files to your message"
 msgstr ""
 
-#: quick-mail.php:3146
+#: quick-mail.php:3149
 msgid "from up to six directories"
 msgstr ""
 
-#: quick-mail.php:3149
+#: quick-mail.php:3152
 msgid "Press Command key while clicking, to select multiple files."
 msgstr ""
 
-#: quick-mail.php:3150
+#: quick-mail.php:3153
 msgid "Press Control key while clicking, to select multiple files."
 msgstr ""
 
-#: quick-mail.php:3151
+#: quick-mail.php:3154
 msgid "You can select multiple files"
 msgstr ""
 
-#: quick-mail.php:3214
+#: quick-mail.php:3217
 msgid "Support"
 msgstr ""
 
-#: quick-mail.php:3229
+#: quick-mail.php:3232
 msgid "Settings"
 msgstr ""

--- a/quick-mail.php
+++ b/quick-mail.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Quick Mail
  * Description: Send text or html email with attachments from user's credentials. Select recipient from users or commenters. Includes WP-CLI command.
- * Version: 4.1.5
+ * Version: 4.1.6
  * Author: Mitchell D. Miller
  * Author URI: https://mitchelldmiller.com/
  * Update URI: https://github.com/mitchelldmiller/quick-mail-wp-plugin/releases/latest
@@ -19,7 +19,7 @@
 /*
  * Quick Mail WordPress Plugin - Send email from WordPress using Quick Mail
  *
- * Copyright (C) 2014-2021 Mitchell D. Miller
+ * Copyright (C) 2014-2022 Mitchell D. Miller
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -60,7 +60,7 @@ class QuickMail {
 	 * @var string version
 	 * @since 3.5.5 10-3-19
 	 */
-	const VERSION = '4.1.5';
+	const VERSION = '4.1.6';
 
 	/**
 	 * Current directory for Quick Mail helper plugins.
@@ -316,6 +316,9 @@ class QuickMail {
 		$current   = array_unique( explode( ' ', $entry ) );
 		$processed = '';
 		foreach ( $current as $one ) {
+		    if (empty($one)) {
+		        continue;
+		    }
 			if ( is_string( strstr( $one, '@' ) ) ) {
 				$a_split = explode( '@', $one );
 				if ( 2 === count( $a_split ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: brainiac
 Tags: mail, email, comments, wp-cli, mailgun, sparkpost, attachment, sendgrid, accessibility, idn, multisite
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=4AAGBFXRAPFJY
 Requires at least: 4.6
-Tested up to: 5.8.2
+Tested up to: 5.8.3
 Requires PHP: 5.3
-Stable tag: 4.1.5
+Stable tag: 4.1.6
 License: MIT
 License URI: https://github.com/mitchelldmiller/quick-mail-wp-plugin/blob/master/LICENSE
 
@@ -108,8 +108,6 @@ Multiple files from up to six directories (folders) can be attached to a message
 * You should be able to find sent emails in your email account's Sent Mail folder.
 
 * Delivery services like [Mailgun](https://www.mailgun.com/), [SparkPost](https://wordpress.org/plugins/sparkpost/) and [Sendgrid](https://sendgrid.com/) also provide this information.
-
-* [WP Mail Logging](https://wordpress.org/plugins/wp-mail-logging/) plugin saves a list of sent emails, with content of message. Plugin shows number of attachments, but does not save attachments or file names.
 
 = Selecting Recipients =
 
@@ -241,6 +239,11 @@ If you are using an email delivery service, you can ignore this message.
 7. User list with roles.
 
 == Changelog ==
+
+= 4.1.6 =
+* Fixed "empty needle" after banned addresses are cleared.
+* Tested with WordPress 5.8.3.
+
 = 4.1.5 =
 * Replace commas with spaces on banned domains.
 * Tested with WordPress 5.8.2.
@@ -281,6 +284,9 @@ If you are using an email delivery service, you can ignore this message.
 Please refer to changelog.txt for changes of previous versions.
 
 == Upgrade Notice ==
+
+= 4.1.6 =
+* Upgrade recommended.
 
 = 4.1.5 =
 * Upgrade recommended.


### PR DESCRIPTION
Fixed "empty needle" after banned addresses are cleared.

Removed WP Mail Logging from docs.

Tested with WordPress 5.8.3.