### PR TITLE
Updates for WP 6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Quick Mail WordPress Plugin
 Send text or html email with attachments and shortcodes from WP Dashboard or command line. Send private replies to comments. Select recipient from users or commenters. Includes WP-CLI command.
 
 * Requires: [WordPress 4.6](https://wordpress.org/support/wordpress-version/version-4-6/)
-* Tested with: [WordPress 6.1](https://wordpress.org/support/wordpress-version/version-6-1/)
-* Stable version: [4.1.6](https://github.com/mitchelldmiller/quick-mail-wp-plugin/releases/latest)
+* Tested with: [WordPress 6.2](https://wordpress.org/documentation/wordpress-version/version-6-2/)
+* Stable version: [4.1.9](https://github.com/mitchelldmiller/quick-mail-wp-plugin/releases/latest)
 
 Description
 -----------
@@ -244,7 +244,7 @@ __Translators and Programmers__
 
 __License__
 
-Quick Mail is licensed under the MIT License. Encourage future development with a [donation](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=4AAGBFXRAPFJY).
+Quick Mail is licensed under the MIT License. Encourage future development with a [donation](https://mitchelldmiller.com/donate).
 
 __Credits__
 

--- a/lang/quick-mail.pot
+++ b/lang/quick-mail.pot
@@ -1,17 +1,17 @@
-# Copyright (C) 2022 Mitchell D. Miller
+# Copyright (C) 2023 Mitchell D. Miller
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: Quick Mail 4.1.6\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/quick-mail-wp-plugin\n"
+"Project-Id-Version: Quick Mail 4.1.9\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/quick-mail\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2022-01-15T21:20:15-05:00\n"
+"POT-Creation-Date: 2023-04-07T21:29:09-04:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.5.0\n"
+"X-Generator: WP-CLI 2.8.0-alpha-db8093b\n"
 "X-Domain: quick-mail\n"
 
 #. Plugin Name of the plugin

--- a/quick-mail.php
+++ b/quick-mail.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Quick Mail
  * Description: Send text or html email with attachments from user's credentials. Select recipient from users or commenters. Includes WP-CLI command.
- * Version: 4.1.6
+ * Version: 4.1.9
  * Author: Mitchell D. Miller
  * Author URI: https://mitchelldmiller.com/
  * Update URI: https://github.com/mitchelldmiller/quick-mail-wp-plugin/releases/latest
@@ -19,7 +19,7 @@
 /*
  * Quick Mail WordPress Plugin - Send email from WordPress using Quick Mail
  *
- * Copyright (C) 2014-2022 Mitchell D. Miller
+ * Copyright (C) 2014-2023 Mitchell D. Miller
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -60,7 +60,7 @@ class QuickMail {
 	 * @var string version
 	 * @since 3.5.5 10-3-19
 	 */
-	const VERSION = '4.1.6';
+	const VERSION = '4.1.9';
 
 	/**
 	 * Current directory for Quick Mail helper plugins.

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: brainiac
 Tags: mail, email, comments, wp-cli, mailgun, sparkpost, attachment, sendgrid, accessibility, idn, multisite
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=4AAGBFXRAPFJY
 Requires at least: 4.6
-Tested up to: 6.1
+Tested up to: 6.2
 Requires PHP: 5.3
-Stable tag: 4.1.6
+Stable tag: 4.1.9
 License: MIT
 License URI: https://github.com/mitchelldmiller/quick-mail-wp-plugin/blob/master/LICENSE
 
@@ -239,6 +239,10 @@ If you are using an email delivery service, you can ignore this message.
 
 == Changelog ==
 
+= 4.1.9 =
+* Updated versions, readme.
+* Tested with WordPress 6.2
+
 = 4.1.6 =
 * Fixed "empty needle" after banned addresses are cleared.
 * Tested with WordPress 5.8.3.
@@ -284,6 +288,9 @@ Please refer to changelog.txt for changes of previous versions.
 
 == Upgrade Notice ==
 
+= 4.1.9 =
+* Upgrade optional.
+
 = 4.1.6 =
 * Upgrade recommended.
 
@@ -313,7 +320,7 @@ Please refer to changelog.txt for changes of previous versions.
 
 == License ==
 
-Quick Mail is free for personal or commercial use. Please support future development with a [donation](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=4AAGBFXRAPFJY).
+Quick Mail is free for personal or commercial use. Please support future development with a [donation](https://mitchelldmiller.com/donate).
 
 == Credits ==
 


### PR DESCRIPTION
Needed updates for WordPress 6.2. Updated versions, readme. Tested with WordPress 6.2.