### PR TITLE
Update WordPress version on "Tested Up to"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Quick Mail WordPress Plugin
 Quick Mail makes it easy to send email with attachments and shortcodes from your WP dashboard or command line. Reply privately to comments. Choose recipients from users or commenters. Multisite compatible. Includes powerful WP-CLI command.
 
 * Requires: [WordPress 4.6](https://wordpress.org/support/wordpress-version/version-4-6/)
-* Tested up to: [WordPress 6.6](https://wordpress.org/documentation/wordpress-version/version-6-6/)
+* Tested up to: [WordPress 6.7](https://wordpress.org/news/2024/11/rollins/)
 * Stable version: [4.1.9](https://github.com/mitchelldmiller/quick-mail-wp-plugin/releases/latest)
 
 Description

--- a/quick-mail.php
+++ b/quick-mail.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Quick Mail
- * Description: Quick Mail makes it easy to send email with attachments and shortcodes from your WP dashboard or command line. Reply privately to comments. Choose recipients from users or commenters. Multisite compatible. Includes powerful WP-CLI command.
+ * Description: Send emails with attachments and shortcodes from WP dashboard. Reply privately to comments. Select recipients from users or commenters. Compatible with Multisite. Does not use Gutenberg or REST API. Includes a powerful WP-CLI command for command-line operations.
  * Version: 4.1.9
  * Author: Mitchell D. Miller
  * Author URI: https://mitchelldmiller.com/

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: brainiac
 Tags: mail, email, comments, wp-cli, mailgun, sparkpost, attachment, sendgrid, accessibility, idn, multisite
 Donate link: https://mitchelldmiller.com/donate
 Requires at least: 4.6
-Tested up to: 6.6
+Tested up to: 6.7
 Requires PHP: 5.3
 Stable tag: 4.1.9
 License: MIT
@@ -253,7 +253,7 @@ If you are using an email delivery service, you can ignore this message.
 
 = 4.1.9 =
 * Updated versions, readme.
-* Tested with WordPress 6.2
+* Tested with WordPress 6.7
 
 = 4.1.6 =
 * Fixed "empty needle" after banned addresses are cleared.


### PR DESCRIPTION
The nice people at WordPress released [version 6.7](https://wordpress.com/blog/2024/11/12/wordpress-6-7/). I tested Quick Mail and it plays nicely with their latest and greatest.

**Changes:**
- Updated the "Tested up to" field to 6.7.
- Updated description.

Closes #32