### PR TITLE
Update "Tested up to" for WordPress 6.8 "Cecil"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Quick Mail WordPress Plugin
 Quick Mail makes it easy to send email with attachments and shortcodes from your WP dashboard or command line. Reply privately to comments. Choose recipients from users or commenters. Multisite compatible. Includes powerful WP-CLI command.
 
 * Requires: [WordPress 4.6](https://wordpress.org/support/wordpress-version/version-4-6/)
-* Tested up to: [WordPress 6.7](https://wordpress.org/news/2024/11/rollins/)
-* Stable version: [4.1.9](https://github.com/mitchelldmiller/quick-mail-wp-plugin/releases/latest)
+* Tested up to: [WordPress 6.8](https://wordpress.org/news/2025/04/cecil/)
+* Stable version: [4.1.10](https://github.com/mitchelldmiller/quick-mail-wp-plugin/releases/latest)
 
 Description
 -----------

--- a/lang/quick-mail.pot
+++ b/lang/quick-mail.pot
@@ -1,15 +1,15 @@
-# Copyright (C) 2024 Mitchell D. Miller
+# Copyright (C) 2025 Mitchell D. Miller
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: Quick Mail 4.1.9\n"
+"Project-Id-Version: Quick Mail 4.1.10\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/quick-mail\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-07-23T19:20:21-04:00\n"
+"POT-Creation-Date: 2025-04-26T19:32:32-04:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.8.0-alpha-db8093b\n"
 "X-Domain: quick-mail\n"
@@ -27,7 +27,7 @@ msgid "https://mitchelldmiller.github.io/quick-mail-wp-plugin/"
 msgstr ""
 
 #. Description of the plugin
-msgid "Quick Mail plugin makes it easy to send email with attachments and shortcodes from your WP dashboard or command line. Reply privately to comments, choose recipients from users or commenters, multisite compatible. Includes powerful WP-CLI command."
+msgid "Send emails with attachments and shortcodes from WP dashboard. Reply privately to comments. Select recipients from users or commenters. Compatible with Multisite. Does not use Gutenberg or REST API. Includes a powerful WP-CLI command for command-line operations."
 msgstr ""
 
 #. Author of the plugin

--- a/quick-mail.php
+++ b/quick-mail.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Quick Mail
  * Description: Send emails with attachments and shortcodes from WP dashboard. Reply privately to comments. Select recipients from users or commenters. Compatible with Multisite. Does not use Gutenberg or REST API. Includes a powerful WP-CLI command for command-line operations.
- * Version: 4.1.9
+ * Version: 4.1.10
  * Author: Mitchell D. Miller
  * Author URI: https://mitchelldmiller.com/
  * Update URI: https://github.com/mitchelldmiller/quick-mail-wp-plugin/releases/latest
@@ -19,7 +19,7 @@
 /*
  * Quick Mail WordPress Plugin - Send email from WordPress using Quick Mail
  *
- * Copyright (C) 2014-2024 Mitchell D. Miller
+ * Copyright (C) 2014-2025 Mitchell D. Miller
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -60,7 +60,7 @@ class QuickMail {
 	 * @var string version
 	 * @since 3.5.5 10-3-19
 	 */
-	const VERSION = '4.1.9';
+	const VERSION = '4.1.10';
 
 	/**
 	 * Current directory for Quick Mail helper plugins.

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: brainiac
 Tags: mail, email, comments, wp-cli, mailgun, sparkpost, attachment, sendgrid, accessibility, idn, multisite
 Donate link: https://mitchelldmiller.com/donate
 Requires at least: 4.6
-Tested up to: 6.7
+Tested up to: 6.8
 Requires PHP: 5.3
-Stable tag: 4.1.9
+Stable tag: 4.1.10
 License: MIT
 License URI: https://github.com/mitchelldmiller/quick-mail-wp-plugin/blob/master/LICENSE
 


### PR DESCRIPTION
Update WordPress version on "Tested Up to"

Tested up to WordPress 6.8.

Closes #34